### PR TITLE
feat: Add request timeout support

### DIFF
--- a/gateway/cmd/config.go
+++ b/gateway/cmd/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	Host string `mapstructure:"host"`
+	Host string `yaml:"host" mapstructure:"host" json:"host,omitempty" default:"http://localhost:8080"`
 }
 
 func LoadConfig() (*Config, error) {

--- a/gateway/cmd/keygen.go
+++ b/gateway/cmd/keygen.go
@@ -15,9 +15,9 @@ func GenEncryptionKeyCommand() *cobra.Command {
 		Use:   "keygen",
 		Short: "Generate encryption key",
 		Long: heredoc.Doc(`
-			Generate encryption key encoded as base64 for encrypting/decrypting connection config`),
+			Generate encryption key encoded as base64 for encrypting/decrypting provider config`),
 		Example: heredoc.Doc(`
-			$ conman keygen`),
+			$ gateway keygen`),
 		RunE: func(c *cobra.Command, args []string) error {
 			key := cryptopasta.NewEncryptionKey()
 			slog.Info(fmt.Sprintf("Encryption key: %s", base64.RawStdEncoding.EncodeToString(key[:])))

--- a/gateway/cmd/serve.go
+++ b/gateway/cmd/serve.go
@@ -69,14 +69,15 @@ func Serve(cfg *config.Config) *api.API {
 	iProviderService := iprovider.NewService()
 
 	return &api.API{
-		RestConfig:       restConfig,
-		DBClient:         dbClient,
 		Logger:           logger,
+		DBClient:         dbClient,
 		Ingester:         ingester,
+		RestConfig:       restConfig,
 		RateLimiter:      ratelimiter,
 		APIKeyService:    apikeyService,
 		PromptService:    promptService,
 		ProviderService:  providerService,
 		IProviderService: iProviderService,
+		RequestTimeout:   cfg.App.RequestTimeout,
 	}
 }

--- a/gateway/internal/api/api.go
+++ b/gateway/internal/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/missingstudio/ai/gateway/core/apikey"
 	"github.com/missingstudio/ai/gateway/core/connection"
@@ -22,6 +23,7 @@ type API struct {
 	RestConfig        *rest.Config
 	DBClient          *database.Client
 	RestServer        *rest.Server
+	RequestTimeout    time.Duration
 	Ingester          ingester.Ingester
 	RateLimiter       *ratelimiter.RateLimiter
 	APIKeyService     *apikey.Service

--- a/gateway/internal/api/config.go
+++ b/gateway/internal/api/config.go
@@ -1,8 +1,11 @@
 package api
 
+import "time"
+
 type Config struct {
 	Host           string               `yaml:"host" json:"host,omitempty" mapstructure:"host" default:"0.0.0.0"`
 	Port           int                  `yaml:"port" json:"port,omitempty" mapstructure:"port" default:"8080"`
+	RequestTimeout time.Duration        `yaml:"request_timeout" json:"request_timeout,omitempty" mapstructure:"request_timeout" default:"5s"`
 	Authentication AuthenticationConfig `yaml:"authentication" mapstructure:"authentication"`
 }
 

--- a/gateway/internal/api/routes.go
+++ b/gateway/internal/api/routes.go
@@ -45,6 +45,7 @@ func (api *API) routes() *chi.Mux {
 		otelconnectInterceptor,
 		interceptor.NewAPIKeyInterceptor(api.Logger, api.APIKeyService, false),
 		interceptor.WithHeaderConfig(),
+		interceptor.WithTimeout(api.RequestTimeout),
 		interceptor.RateLimiterInterceptor(api.RateLimiter),
 		interceptor.RetryInterceptor(),
 		interceptor.NewLoggingInterceptor(api.Logger),

--- a/gateway/internal/constants/contants.go
+++ b/gateway/internal/constants/contants.go
@@ -18,14 +18,15 @@ const (
 )
 
 const (
-	XMSAPIKey     = "X-MS-Api-Key"
-	XMSProvider   = "X-MS-Provider"
-	XMSConfig     = "X-MS-Config"
-	Authorization = "Authorization"
-	XMSCache      = "X-MS-Cache"
-	XMSRequestId  = "X-MS-Request-Id"
-	XMSTraceId    = "X-MS-Trace-Id"
-	XMSRetryCount = "X-MS-Retry-count"
+	XMSAPIKey         = "X-MS-Api-Key"
+	XMSProvider       = "X-MS-Provider"
+	XMSConfig         = "X-MS-Config"
+	Authorization     = "Authorization"
+	XMSCache          = "X-MS-Cache"
+	XMSRequestId      = "X-MS-Request-Id"
+	XMSTraceId        = "X-MS-Trace-Id"
+	XMSRetryCount     = "X-MS-Retry-count"
+	XMSRequestTimeout = "X-MS-Request-Timeout"
 )
 
 const (

--- a/gateway/internal/interceptor/logging.go
+++ b/gateway/internal/interceptor/logging.go
@@ -32,7 +32,7 @@ func (l *loggingInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc
 		if err != nil {
 			if err, ok := err.(*connect.Error); ok {
 				switch err.Code() {
-				case connect.CodeUnknown:
+				case connect.CodeInternal, connect.CodeUnknown:
 					resultStatus = http.StatusInternalServerError
 				default:
 					resultStatus = http.StatusBadRequest

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	// Cli config to connect with GRPC server
+	// Load CLI configuration to connect with GRPC server
 	cliConfig, err := cmd.LoadConfig()
 	if err != nil {
 		cliConfig = &cmd.Config{}


### PR DESCRIPTION
- Default request timeout can be utilized, or the application-level request timeout configuration in the application's config.yaml can be updated.
- For defining request timeouts on a per-request basis, the X-MS-Request-Timeout header can be modified.